### PR TITLE
[1.4.4-rc.4] HUD Timer for Guide job

### DIFF
--- a/configs/text/eng/ui_st_mm.xml
+++ b/configs/text/eng/ui_st_mm.xml
@@ -579,6 +579,9 @@
 	<string id="ui_mm_show_guide_job_on_map">
 		<text>Show guide job on map</text>
 	</string>
+	<string id="ui_mm_show_guide_job_hud_timer">
+		<text>Show guide job timer</text>
+	</string>
 	<string id="ui_mm_alife_switch_dist">
 		<text>Online switch distance</text>
 	</string>

--- a/configs/text/rus/ui_st_mm.xml
+++ b/configs/text/rus/ui_st_mm.xml
@@ -582,6 +582,9 @@
 	<string id="ui_mm_show_guide_job_on_map">
 		<text>Показ. меток проводника</text>
 	</string>
+	<string id="ui_mm_show_guide_job_hud_timer">
+		<text>Показ. таймер проводника</text>
+	</string>
 	<string id="ui_mm_alife_switch_dist">
 		<text>Радиус жизни на локации</text>
 	</string>

--- a/configs/ui/ui_hud_timer_2.xml
+++ b/configs/ui/ui_hud_timer_2.xml
@@ -1,0 +1,10 @@
+<w>
+	<hud_timer_2 x="869" y="0" width="155" height="66" stretch="1">
+		<background>
+			<texture>ui_hud_timer_games</texture>
+		</background>
+		<time x="140" y="23" stretch="1">
+			<text font="graffiti32" r="238" g="155" b="23" a="255" align="r"/>
+		</time>
+	</hud_timer_2>
+</w>

--- a/scripts/axr_main_options.script
+++ b/scripts/axr_main_options.script
@@ -193,6 +193,14 @@ function opt_menu_on_init(menu)
 		menu.gameplay_options["alife_switch_dist"] = {default=150, debug_only=false, typ="list", list={100,150,200,250}, on_accept=function(handler,optMgr,ctrl)
 			SetSwitchDistance(tonumber(ctrl:GetText()))
 		end}
+		
+		menu.gameplay_options["show_guide_job_hud_timer"] = {default=true, debug_only=false, typ="check", on_accept=function(handler,optMgr,ctrl)
+				if (ctrl:GetCheck()) then
+					jg_hud_timer.try_start()
+				else
+					jg_hud_timer.try_stop()
+				end
+			end}
 		--
 	end
 	

--- a/scripts/jg_guider.script
+++ b/scripts/jg_guider.script
@@ -136,6 +136,8 @@ function activate()
 	jg_timers.g_start_timer('guid_fail',0,curr_guid['timer'],0,'jg_guider','fail_time')
 	jg_timers.stop_g_timer('guid_msg')
 	
+	jg_hud_timer.try_start()
+	
 	if (axr_main_options.get_check_option("show_guide_job_on_map")) then
 		local pos = vector():set(curr_guid.pos[1], curr_guid.pos[2], curr_guid.pos[3])
 		local lvid = level.vertex_id(pos)
@@ -204,6 +206,7 @@ function fail()
 	xr_statistic.inc_actor_reputation(-500)
 	local snpc = alife():object(get_comm_id(curr_guid['squad_id']))
 	alun_utils.execute_script_on_squad(snpc,axr_companions.remove_from_actor_squad)
+	jg_hud_timer.try_stop()
 	clear()
 end
 
@@ -273,9 +276,7 @@ function get_phrase3()
 end
 
 function get_phrase4()
-	local left_minutes_total = jg_timers.get_g_timer_left_time('guid_fail')
-	local left_hours = math.floor(left_minutes_total / 60)
-	local left_minutes = left_minutes_total - (left_hours * 60)
+	local left_hours, left_minutes = get_time_left()
 	local phrase = strformat(strtransl('st_jg_21'), left_hours, left_minutes)
 	return phrase
 end
@@ -322,4 +323,11 @@ function has_time_bonus()
 		result = minutes_left > math.floor(minutes_total * curr_guid.bonus_time_cf)
 	end
 	return result
+end
+
+function get_time_left()
+	local minutes_total = jg_timers.get_g_timer_left_time('guid_fail')
+	local hours = math.floor(minutes_total / 60)
+	local minutes = minutes_total - (hours * 60)
+	return hours, minutes
 end

--- a/scripts/jg_hud_timer.script
+++ b/scripts/jg_hud_timer.script
@@ -27,7 +27,7 @@ function on_game_start()
 end
 
 function try_start()
-	if (hud_timer or not jg_guider.has_guiding_started()) then
+	if (hud_timer or not jg_guider.has_guiding_started() or not axr_main_options.get_check_option("show_guide_job_hud_timer")) then
 		return
 	end
 	

--- a/scripts/jg_hud_timer.script
+++ b/scripts/jg_hud_timer.script
@@ -1,0 +1,55 @@
+--
+-- HUD code for Guider job
+-- Author: Dancher
+--
+
+local hud_timer
+local last_minute
+
+local function actor_on_slicing_update()
+	local current_minute = level.get_time_minutes()
+	
+	if (last_minute and last_minute == current_minute) then
+		return
+	end
+	last_minute = current_minute
+	
+	local left_hours, left_minutes = jg_guider.get_time_left()
+	hud_timer:SetValue(left_hours, left_minutes, 0)
+end
+
+local function on_game_load()
+	try_start()
+end
+
+function on_game_start()
+	RegisterScriptCallback("on_game_load",on_game_load)
+end
+
+function try_start()
+	if (hud_timer or not jg_guider.has_guiding_started()) then
+		return
+	end
+	
+	hud_timer = ui_hud_timer.create()
+	RegisterScriptCallback("actor_on_slicing_update",actor_on_slicing_update)
+	
+	local function tickback()
+		hud_timer:Show(main_hud_shown())
+	end
+	StartTimer("jg_hud_show_timer", 1000, tickback)
+end
+
+function try_stop()
+	if (not hud_timer) then
+		return
+	end
+	
+	StopTimer("jg_hud_show_timer")
+	
+	UnregisterScriptCallback("actor_on_slicing_update",actor_on_slicing_update)
+	last_minute = nil
+	
+	hud_timer:Clear()
+	hud_timer = nil
+end

--- a/scripts/ui_hud_timer.script
+++ b/scripts/ui_hud_timer.script
@@ -26,11 +26,11 @@ function hud_timer_ui:InitControls()
 	
 	local timer_ui_name = "hud_timer"
 	self.owner:AddCustomStatic(timer_ui_name, true)
-	self.time_format_strting = "%s:%s:%s"
+	self.time_format = "%s:%s:%s"
 	self.text_control = self.owner:GetCustomStatic(timer_ui_name):wnd():TextControl()
 end
 
-function hud_timer_ui:SetValue(hours, minutes, seconds)
-	local value = strformat(self.time_format_strting, hours, minutes, seconds)
+function hud_timer_ui:SetValue(arg1, arg2, arg3)
+	local value = strformat(self.time_format, arg1, arg2, arg3)
 	self.text_control:SetTextST(value)
 end

--- a/scripts/ui_hud_timer.script
+++ b/scripts/ui_hud_timer.script
@@ -12,9 +12,15 @@ function hud_timer_ui:__init() super()
 	self.owner = get_hud()
 	self:InitControls()
 	self:SetValue(0,0,0)
+	self.owner:AddDialogToRender(self)
 end
 
 function hud_timer_ui:__finalize()
+	self:Clear()
+end
+
+function hud_timer_ui:Clear()
+	self.owner:RemoveDialogToRender(self)
 end
 
 function hud_timer_ui:InitControls()
@@ -22,15 +28,18 @@ function hud_timer_ui:InitControls()
     if(device().width/device().height>(1024/768+0.01)) then
         wide = true
     end
-    self:SetAutoDelete(true)
 	
-	local timer_ui_name = "hud_timer"
-	self.owner:AddCustomStatic(timer_ui_name, true)
+	local xml = CScriptXmlInit()
+    xml:ParseFile("ui_hud_timer_2.xml")
+	
+	self.dialog = xml:InitStatic("hud_timer_2", self)
+	self.background = xml:InitStatic("hud_timer_2:background", self.dialog)
+	self.time = xml:InitTextWnd("hud_timer_2:time", self.dialog)
+	
 	self.time_format = "%s:%s:%s"
-	self.text_control = self.owner:GetCustomStatic(timer_ui_name):wnd():TextControl()
 end
 
 function hud_timer_ui:SetValue(arg1, arg2, arg3)
 	local value = strformat(self.time_format, arg1, arg2, arg3)
-	self.text_control:SetTextST(value)
+	self.time:SetText(value)
 end


### PR DESCRIPTION
## Description
Added HUD Timer for Guide job to see how much time is remaining.

## What's new
* Changed args of `hud_timer_ui:SetValue` function
* Reworked init code of `hud_timer_ui` from static to dialog
* Added `jg_hud_timer.script` to update HUD timer of Guide job
* Added `show_guide_job_hud_timer` option

## Screenshots
<details>
<summary>Spoiler</summary>

![ss_denie_08-06-24_01-41-46_(l10_limansk)](https://github.com/user-attachments/assets/04936de7-7f82-45dd-81eb-89c18cb12612)
</details>