### PR TITLE
[v1.5.0-beta.5] Random stashes renewing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ All notable changes to this project will be documented in this file.
 * Added var types constants into `_g.script`
 * Added `parse_ini_section_to_iarray` function into `utils.script`
 * Added original `lua_help.script`
+* Added `level_time_observer.script` to be able to observe game time
 
 ## [1.4.6] - Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 * Added old new night visions: 1 gen from Clear Sky, 2 gen from SoC
 * Reworked global map texture based on Clear Sky texture
 * Restored fog ambient
+* Random stashes renewing
 
 ### Improvements
 * Restored lore-friendly NPC's backpack textures

--- a/configs/plugins/coc_treasure_manager.ltx
+++ b/configs/plugins/coc_treasure_manager.ltx
@@ -144,3 +144,9 @@ wpn_wincheaster1300_trapper
 ;List of inventory boxes to exclude from random stashes
 [ignore_boxes]
 bar_arena_inventory_box_2
+
+;Stashes self-renewing
+[renewing]
+min_time = 720
+max_time = 2160
+chance = 0.5

--- a/scripts/axr_companions_trust.script
+++ b/scripts/axr_companions_trust.script
@@ -6,7 +6,6 @@
 local database = {}
 
 local trust_time_threshold = 24*60
-local last_game_minute
 
 local time_key = "time"
 local trust_key = "trust"
@@ -70,20 +69,12 @@ local function load_state(data)
 	end
 end
 
-local function actor_on_slicing_update()
-	local current_game_minute  = level.get_time_minutes()
-	
-	if (current_game_minute == last_game_minute) then
-		return
-	end
-	
+local function level_time_on_changed()
 	update_data()
-	
-	last_game_minute = current_game_minute
 end
 
 function on_game_start()
-    RegisterScriptCallback("actor_on_slicing_update", actor_on_slicing_update)
+    RegisterScriptCallback("level_time_on_changed", level_time_on_changed)
 	RegisterScriptCallback("save_state",save_state)
 	RegisterScriptCallback("load_state",load_state)
 end

--- a/scripts/axr_main.script
+++ b/scripts/axr_main.script
@@ -173,8 +173,9 @@ local intercepts = {
 	surge_on_ended					= {},
 	psi_storm_on_ended				= {},
 	
-	npc_on_use_dead					= {}
-	--
+	npc_on_use_dead					= {},
+	
+	level_time_on_changed			= {}
 }
 
 -----------------------------------------------------------

--- a/scripts/coc_treasure_manager.script
+++ b/scripts/coc_treasure_manager.script
@@ -38,12 +38,20 @@ will find the <filename>.lua in your savegame folder. Search the file for 'cache
 caches = {}
 local caches_count = 0
 
+local renewing_time = 0
+local renewing_next_time = 0
+local renewing_counter = 0
+
 local ltx = ini_file("plugins\\coc_treasure_manager.ltx")
 local valid_item_list = nil
 ------------------------------------------------------------------------------------------------------------------
 --							PRIVATE
 ------------------------------------------------------------------------------------------------------------------
 local function on_game_load()
+	if (renewing_next_time == 0) then
+		renewing_next_time = get_renewing_next_time()
+	end
+	
 	if (caches_count > 0) then
 		return
 	end
@@ -80,6 +88,7 @@ end
 local function actor_on_item_take_from_box(box,itm)
 	if (caches[box:id()] == true) then
 		caches[box:id()] = false
+		renewing_counter = renewing_counter + 1
 		local hud = get_cached_hud()
 		if (hud and box:is_inv_box_empty()) then
 			hud:HideActorMenu()
@@ -98,6 +107,14 @@ local function actor_on_item_take_from_box(box,itm)
 	end
 end
 
+local function level_time_on_changed()
+	renewing_time = renewing_time + 1
+end
+
+local function on_level_changing()
+	renew_random_stashes()
+end
+
 local function save_state(data)
 	--alun_utils.debug_write("coc_treasure_manager.save_state")
 	if (caches_count <= 0) then
@@ -110,6 +127,9 @@ local function save_state(data)
 
 	data.coc_treasure_manager.caches_count = caches_count
 	data.coc_treasure_manager.caches = caches
+	data.coc_treasure_manager.renewing_time = renewing_time
+	data.coc_treasure_manager.renewing_next_time = renewing_next_time
+	data.coc_treasure_manager.renewing_counter = renewing_counter
 end
 
 local function load_state(data)
@@ -119,9 +139,15 @@ local function load_state(data)
 
 	caches_count = data.coc_treasure_manager.caches_count or caches_count
 	caches = data.coc_treasure_manager.caches or caches
+	renewing_time = data.coc_treasure_manager.renewing_time or renewing_time
+	renewing_next_time = data.coc_treasure_manager.renewing_next_time or renewing_next_time
+	renewing_counter = data.coc_treasure_manager.renewing_counter or renewing_counter
 
 	data.coc_treasure_manager.caches_count = nil
 	data.coc_treasure_manager.caches = nil
+	data.coc_treasure_manager.renewing_time = nil
+	data.coc_treasure_manager.renewing_next_time = nil
+	data.coc_treasure_manager.renewing_counter = nil
 end
 
 local function physic_object_on_use_callback(box,who)
@@ -135,6 +161,8 @@ end
 function on_game_start()
 	RegisterScriptCallback("on_game_load",on_game_load)
 	RegisterScriptCallback("actor_on_item_take_from_box",actor_on_item_take_from_box)
+	RegisterScriptCallback("level_time_on_changed",level_time_on_changed)
+	RegisterScriptCallback("on_level_changing",on_level_changing)
 	RegisterScriptCallback("save_state",save_state)
 	RegisterScriptCallback("load_state",load_state)
 	RegisterScriptCallback("physic_object_on_use_callback",physic_object_on_use_callback)
@@ -750,4 +778,40 @@ function get_extended_hint(sim,stash,hint,id)
 	local extended_hint = "%c[255,255,160,0]" .. name .. "\\n%c[default]" .. descr .. "\\n%c[160,0,255,255]" .. (hint or STR_EMPTY)
 
 	return extended_hint, name
+end
+
+function get_renewing_next_time()
+	local renewing_section = "renewing"
+	local min_time = ltx:r_string_ex(renewing_section,"min_time") or STR_ZERO
+	local max_time = ltx:r_string_ex(renewing_section,"max_time") or STR_ZERO
+
+	min_time = tonumber(min_time)
+	max_time = tonumber(max_time)
+	
+	return math.random(min_time, max_time)
+end
+
+function get_renewing_chance()
+	local chance = ltx:r_string_ex("renewing","chance") or STR_ZERO
+	
+	return tonumber(chance)
+end
+
+function renew_random_stashes()
+	if (renewing_counter == 0 or 
+		renewing_time < renewing_next_time)
+	then
+		return
+	end
+	
+	local chance = get_renewing_chance()
+	
+	for i=1,renewing_counter do
+		if (math.random() < chance) then
+			create_random_stash(true,STR_EMPTY)
+		end
+	end
+	
+	renewing_counter = 0
+	renewing_next_time = get_renewing_next_time()
 end

--- a/scripts/level_time_observer.script
+++ b/scripts/level_time_observer.script
@@ -1,0 +1,22 @@
+--
+-- Level Time Observer
+-- Added by Dancher
+--
+
+local last_game_minute
+
+local function actor_on_slicing_update()
+	local game_minute  = level.get_time_minutes()
+	
+	if (game_minute == last_game_minute) then
+		return
+	end
+	
+	last_game_minute = game_minute
+	
+	SendScriptCallback("level_time_on_changed",game_minute,last_game_minute)
+end
+
+function on_game_start()
+    RegisterScriptCallback("actor_on_slicing_update", actor_on_slicing_update)
+end

--- a/scripts/level_time_observer.script
+++ b/scripts/level_time_observer.script
@@ -12,9 +12,9 @@ local function actor_on_slicing_update()
 		return
 	end
 	
-	last_game_minute = game_minute
-	
 	SendScriptCallback("level_time_on_changed",game_minute,last_game_minute)
+	
+	last_game_minute = game_minute
 end
 
 function on_game_start()


### PR DESCRIPTION
## Description
Added random stashes renewing

## What's new
1. Added `level_time_observer.script` to be able to observe game time
2. Replaced `actor_on_slicing_update` with `level_time_on_changed` callback in `axr_companions_trust.script`
3. Added stashes renewing into `coc_treasure_manager.ltx` and `coc_treasure_manager.script`