### PR TITLE
[v1.5.2-rc.2] Reworked Survival mode with EOC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [1.5.2] - Unreleased
 
+### Features
+* Added Offline Combat to basic mode
+* Reworked Survival mode with EOC
+
 ### Mods
 * [ND fix NPC guitar position coc 1.4.22](https://www.moddb.com/mods/call-of-chernobyl/addons/nd-fix-npc-guitar-position-coc1-4-22)
 * [Disappearing Rain Sound Fix](https://www.moddb.com/mods/doctorx-call-of-the-zone/addons/disappearing-rain-sound-fix)
@@ -24,6 +28,7 @@ All notable changes to this project will be documented in this file.
 * Refactored `actor_health_effectors.script`
 * Restored original `printf` after disabling debug messages in `game_relations.script` (783a008)
 * Corrected chance of picking squad target
+* Corrected bandits `faction_boost` value from 5 to 8 in `sim_offline_control.script` (EOC mode)
 
 ### Fixes
 * Changed last period change date format for saves in `level_weathers.script`
@@ -41,6 +46,7 @@ All notable changes to this project will be documented in this file.
 * Fixed changing of faction relations if actor killed NPC under disguise
 * Disabled `sim_squad_scripted:sim_available()` function to prevent oversimulation
 * Saved `idle_time` and `stay_time` to fix reselection after reload in `sim_squad_scripted.script`
+* Fixed and refactored `are_factions_zombied_or_monster` function in `sim_survival.script`
 
 ### Optimization
 * Added `npc_count` into `CCampManager` to optimize update calls (from [[EN/RU] More campfire jokes and stories](https://www.moddb.com/mods/stalker-anomaly/addons/enru-more-campfire-jokes-and-stories) mod)

--- a/scripts/sim_combat_manager.script
+++ b/scripts/sim_combat_manager.script
@@ -49,7 +49,7 @@ function sim_combat_manager:find_enemy(squad)
 				squad2_power = sim_offline_control.ocs_power_table[s]
 				
 				local are_enemies = nil
-				if (IsSurvivalMode() and sim_survival.are_factions_zombied_or_monster(faction, faction2)) then
+				if (IsSurvivalMode() and sim_survival.are_factions_zombied_and_monster(faction, faction2)) then
 					are_enemies = false
 				else
 					if (faction == "monster" and faction2 == "monster") then
@@ -83,7 +83,7 @@ function sim_combat_manager:is_valid()
 					squad2_power = sim_offline_control.ocs_power_table[s]
 					
 					local are_enemies = nil
-					if (IsSurvivalMode() and sim_survival.are_factions_zombied_or_monster(faction, faction2)) then
+					if (IsSurvivalMode() and sim_survival.are_factions_zombied_and_monster(faction, faction2)) then
 						are_enemies = false
 					else
 						if (faction == "monster" and faction2 == "monster") then

--- a/scripts/sim_offline_control.script
+++ b/scripts/sim_offline_control.script
@@ -32,7 +32,7 @@ function calculate_squad_power(squad)
 	if faction == "stalker" then
 	   faction_boost = 8
 	elseif faction == "bandit" then
-	   faction_boost = 5
+	   faction_boost = 8
 	elseif faction == "csky" then
 	   faction_boost = 10
 	elseif faction == "army" then
@@ -47,6 +47,8 @@ function calculate_squad_power(squad)
 	   faction_boost = 10
 	elseif faction == "monolith" then
 	   faction_boost = 15
+	elseif faction == "zombied" and IsSurvivalMode() then
+	   faction_boost = 10
 	end
 
 	power = power + faction_boost

--- a/scripts/sim_smart.script
+++ b/scripts/sim_smart.script
@@ -107,11 +107,23 @@ function try_to_respawn_faction(smart)
 		return
 	end
 
+	if (IsSurvivalMode() and sim_survival.can_replace_faction_respawn()) then
+		local faction = "zombied"
+		local base_count = sim_factions.faction_information[faction].base_count or 0
+		sim_factions.faction_information[faction].base_count = base_count + 1
+		local count = math.random(1,sim_survival.get_zombied_respawn_squads_count())
+		for i=1,count do
+			sim_squad.create_squad(smart, faction, nil, nil, nil, 1)
+		end
+		printf("### EOC: -- replaced faction respawn by zombied - ".. smart:name() .." ###")
+		return
+	end
+	
 	for i,faction in pairs(sim_tables.factions) do 
 		if faction ~= "monster" then
 		   if (sim_factions.faction_information[faction].base_count) and sim_factions.faction_information[faction].base_count < 1 then
 			  sim_factions.faction_information[faction].base_count = 1
-			  sim_squad.create_squad(smart, faction, nil, nil, nil, 1, true)
+			  sim_squad.create_squad(smart, faction, nil, nil, nil, 1)
 			  printf("### EOC: -- try_to_respawn_faction -- ".. faction .." - ".. smart:name() .." ###")
 		   end
 		end

--- a/scripts/sim_squad.script
+++ b/scripts/sim_squad.script
@@ -70,7 +70,7 @@ function squad_control(squad)
 	end
 end
 
-function create_squad(smart, faction, target, type, number, param, is_survival_ignored)
+function create_squad(smart, faction, target, type, number, param)
 	
 	if (has_alife_info("actor_made_wish_for_peace")) then 
 		return 
@@ -111,13 +111,6 @@ function create_squad(smart, faction, target, type, number, param, is_survival_i
 			sim_offline_control.squads_by_level[lvl][squad.id] = true
 	    end  
 	else
-		if (IsSurvivalMode() and not is_survival_ignored) then
-			faction = sim_survival.try_replace_stalker(faction)
-			if (faction == nil) then
-				return
-			end
-		end
-	
 	    local random = math.random(30) + sim_factions.faction_information[faction].resource_count
 	    local section = "novice"
 

--- a/scripts/sim_survival.script
+++ b/scripts/sim_survival.script
@@ -3,8 +3,10 @@
 --	Added by Dancher
 --
 
-local max_delay_hours = 24
-local max_spawn_chance = 90
+local delay_hours = 24
+local zombied_squads_count = 3
+local max_zombied_chance = 0.5
+local max_mutant_chance = 0.8
 
 local enable_debug = false
 
@@ -15,44 +17,37 @@ local function print_dbg(fmt, ...)
 	end
 end
 
-local function get_chance_by_elapsed_hours()
+local function get_chance_by_elapsed_hours(replace_chance)
 	local hours_elapses = utils.get_hours_elapsed()
-	local chance_factor = utils.inverse_lerp(0, max_delay_hours, hours_elapses)
-	local chance = utils.lerp(0 , max_spawn_chance, chance_factor)
-	print_dbg("get_chance_by_elapsed_hours! Factor: %s, chance: %s", chance_factor, chance)
+	local chance_factor = utils.inverse_lerp(0, delay_hours, hours_elapses)
+	local chance = utils.lerp(0 , replace_chance, chance_factor)
+	if enable_debug then print_dbg("get_chance_by_elapsed_hours! Factor: %s, chance: %s", chance_factor, chance) end
 	return chance
 end
 
-function try_replace_stalker(faction)
-	local result_faction = nil
+function get_zombied_respawn_squads_count()
+	return zombied_squads_count
+end
 
-	if (faction ~= "zombied") then
-		local chance = math.random(100)
-		if (chance < get_chance_by_elapsed_hours()) then
-			result_faction = "zombied"
-			print_dbg("FACTION: %s -> %s", faction, result_faction)
-		elseif (chance > max_spawn_chance) then
-			result_faction = faction
-		end
-	end
-
-	return result_faction
+function can_replace_faction_respawn(faction)
+	local chance = math.random()
+	return chance < get_chance_by_elapsed_hours(max_zombied_chance)
 end
 
 function try_replace_mutant(section)
-	local result_section = nil
+	local result_section = section
 	local survival_mutants = sim_tables.mutants_for_survival_mode
+	local is_already_survival_mutant = utils.contains(survival_mutants, section)
 	
-	if (not (utils.contains(survival_mutants, section))) then
-		local chance = math.random(100)
-		if (chance < get_chance_by_elapsed_hours()) then
+	if (is_already_survival_mutant == false) then
+		local chance = math.random()
+		
+		if (chance < get_chance_by_elapsed_hours(max_mutant_chance)) then
 			result_section = survival_mutants[math.random(#survival_mutants)]
 			if (result_section == "simulation_zombie" and math.random() < 0.1) then
 				result_section = "simulation_zombie_ghost"
 			end
-			print_dbg("MUTANT: %s -> %s", section, result_section)
-		elseif (chance > max_spawn_chance) then
-			result_section = section
+			if enable_debug then print_dbg("MUTANT: %s -> %s", section, result_section) end
 		end
 	end
 
@@ -63,9 +58,6 @@ function contains_faction_prop(prop_name, prop_count)
 	return sim_tables.factions_to_zombied_props[prop_name] and prop_count > 0
 end
 
-function are_factions_zombied_or_monster(faction1, faction2)
-	local is_faction1_zombied_or_monster = faction1 == "zombied" or faction1 == "monster"
-	local is_faction2_zombied_or_monster = faction2 == "zombied" or faction2 == "monster"
-	
-	return is_faction1_zombied_or_monster == is_faction2_zombied_or_monster
+function are_factions_zombied_and_monster(f1, f2)
+	return (f1 == "zombied" and f2 == "monster") or (f1 == "monster" and f2 == "zombied")
 end


### PR DESCRIPTION
## Description
Soft reworked logic of Survival mode with EOC.

## What's new

Main changes:
* Removed replacing stalker squads with zombied with a 90% chance.
* Now zombied can spawn in quantities from 1 to 3 with a 50% chance at smarts
* Added `faction_boost` is equal to 10 in Survival mode
* Decreased chance to replace mutant with Survival mutant (zombie, snork, Izlom) from 90% to 80%

Other changes:

* Corrected bandits `faction_boost` value from 5 to 8 in `sim_offline_control.script` (EOC mode)
* Fixed and refactored `are_factions_zombied_or_monster` function in `sim_survival.script`

